### PR TITLE
closes #74; Fix en Gruntfile.js realizado

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -17,7 +17,7 @@ module.exports = function(grunt){
         },
         ts: {
             build: {
-                src: ["src/**/*.ts", "!node_modules/**/*.ts"],
+                src: ["src/**/*.ts", "!node_modules/**/*.ts", "!src/tests/*.ts"],
                 dest: "build/",
                 options: {
                     module: 'commonjs',


### PR DESCRIPTION
Simplemente añadiendo src: [........ "!src/tests/*.ts"], a las fuentes a transpilar conseguimos exluir la transpilación de esos archivos